### PR TITLE
Fix identity transactions request not using range specified in request.

### DIFF
--- a/rpc/query.go
+++ b/rpc/query.go
@@ -126,13 +126,17 @@ func (s *StatusCache) fetchTickIntervals(ctx context.Context) ([]*statusPb.TickI
 	return tickIntervalsResponse.Intervals, nil
 }
 
-func (qb *QueryBuilder) performIdentitiesTransactionsQuery(ctx context.Context, ID string, pageSize, pageNumber int, desc bool) (result TransactionsSearchResponse, err error) {
+func (qb *QueryBuilder) performIdentitiesTransactionsQuery(ctx context.Context, ID string, pageSize, pageNumber int, desc bool, reqStartTick, reqEndTick uint32) (result TransactionsSearchResponse, err error) {
 	maxTick, err := qb.cache.GetMaxTick(ctx)
 	if err != nil {
 		return TransactionsSearchResponse{}, fmt.Errorf("getting max tick from cache: %w", err)
 	}
 
-	query, err := createIdentitiesQuery(ID, pageSize, pageNumber, desc, maxTick)
+	if reqEndTick != 0 {
+		maxTick = reqEndTick
+	}
+
+	query, err := createIdentitiesQuery(ID, pageSize, pageNumber, desc, reqStartTick, maxTick)
 	if err != nil {
 		return TransactionsSearchResponse{}, fmt.Errorf("creating query: %v", err)
 	}
@@ -277,7 +281,7 @@ func (qb *QueryBuilder) performTickTransactionsQuery(ctx context.Context, tick u
 	return result, nil
 }
 
-func createIdentitiesQuery(ID string, pageSize, pageNumber int, desc bool, maxTick uint32) (bytes.Buffer, error) {
+func createIdentitiesQuery(ID string, pageSize, pageNumber int, desc bool, startTick, endTick uint32) (bytes.Buffer, error) {
 	from := pageNumber * pageSize
 	querySort := "asc"
 	if desc {
@@ -285,10 +289,10 @@ func createIdentitiesQuery(ID string, pageSize, pageNumber int, desc bool, maxTi
 	}
 
 	tickNumberRangeFilter := map[string]interface{}{
-		"lte": maxTick,
-		//"gte": 10000000, // min tick can also be implemented if needed
+		"lte": endTick,
+		"gte": startTick,
 	}
-	if maxTick <= 0 {
+	if endTick <= 0 {
 		delete(tickNumberRangeFilter, "lte")
 	}
 

--- a/rpc/query.go
+++ b/rpc/query.go
@@ -127,13 +127,16 @@ func (s *StatusCache) fetchTickIntervals(ctx context.Context) ([]*statusPb.TickI
 }
 
 func (qb *QueryBuilder) performIdentitiesTransactionsQuery(ctx context.Context, ID string, pageSize, pageNumber int, desc bool, reqStartTick, reqEndTick uint32) (result TransactionsSearchResponse, err error) {
-	maxTick, err := qb.cache.GetMaxTick(ctx)
+	statusMaxTick, err := qb.cache.GetMaxTick(ctx)
 	if err != nil {
 		return TransactionsSearchResponse{}, fmt.Errorf("getting max tick from cache: %w", err)
 	}
 
-	if reqEndTick != 0 {
+	var maxTick uint32
+	if reqEndTick != 0 && reqEndTick <= statusMaxTick {
 		maxTick = reqEndTick
+	} else {
+		maxTick = statusMaxTick
 	}
 
 	query, err := createIdentitiesQuery(ID, pageSize, pageNumber, desc, reqStartTick, maxTick)

--- a/rpc/query.go
+++ b/rpc/query.go
@@ -132,14 +132,14 @@ func (qb *QueryBuilder) performIdentitiesTransactionsQuery(ctx context.Context, 
 		return TransactionsSearchResponse{}, fmt.Errorf("getting max tick from cache: %w", err)
 	}
 
-	var maxTick uint32
+	var queryEndTick uint32
 	if reqEndTick != 0 && reqEndTick <= statusMaxTick {
-		maxTick = reqEndTick
+		queryEndTick = reqEndTick
 	} else {
-		maxTick = statusMaxTick
+		queryEndTick = statusMaxTick
 	}
 
-	query, err := createIdentitiesQuery(ID, pageSize, pageNumber, desc, reqStartTick, maxTick)
+	query, err := createIdentitiesQuery(ID, pageSize, pageNumber, desc, reqStartTick, queryEndTick)
 	if err != nil {
 		return TransactionsSearchResponse{}, fmt.Errorf("creating query: %v", err)
 	}

--- a/rpc/rpc_server.go
+++ b/rpc/rpc_server.go
@@ -51,7 +51,7 @@ func (s *Server) GetIdentityTransactions(ctx context.Context, req *protobuf.GetI
 		pageSize = req.GetPageSize()
 	}
 	pageNumber := max(0, int(req.Page)-1) // API index starts with '1', implementation index starts with '0'.
-	response, err := s.qb.performIdentitiesTransactionsQuery(ctx, req.Identity, int(pageSize), pageNumber, req.Desc)
+	response, err := s.qb.performIdentitiesTransactionsQuery(ctx, req.Identity, int(pageSize), pageNumber, req.Desc, 0, 0)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "performing identities transactions query: %s", err.Error())
 	}
@@ -84,7 +84,7 @@ func (s *Server) GetIdentityTransfersInTickRangeV2(ctx context.Context, req *pro
 		pageSize = req.GetPageSize()
 	}
 	pageNumber := max(0, int(req.Page)-1) // API index starts with '1', implementation index starts with '0'.
-	response, err := s.qb.performIdentitiesTransactionsQuery(ctx, req.Identity, int(pageSize), pageNumber, req.Desc)
+	response, err := s.qb.performIdentitiesTransactionsQuery(ctx, req.Identity, int(pageSize), pageNumber, req.Desc, req.StartTick, req.EndTick)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "performing identities transactions query: %s", err.Error())
 	}


### PR DESCRIPTION
Identity transfer transactions request now returns the transactions in the tick range specified by the request parameters.

Closes  #20 