### PR TITLE
chore: generate OpenAPI spec on the fly in docs-update workflow

### DIFF
--- a/.github/workflows/api-docs-update-v2.yaml
+++ b/.github/workflows/api-docs-update-v2.yaml
@@ -6,18 +6,52 @@ on:
     branches:
       - main
     paths:
-      - 'v2/api/archive-query-service/v2/query_services.openapi.yaml' # Only trigger if the OpenAPI spec changed
+      - 'v2/api/archive-query-service/v2/*.proto'
 
 jobs:
   api-docs-update-trigger:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26.x
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Install protoc-gen-openapi
+        run: go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
+
+      - name: Generate OpenAPI spec
+        working-directory: v2
+        run: |
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          make openapi-v3-gen
+
+      - name: Apply OpenAPI adjustments
+        run: |
+          cd v2/api/archive-query-service/v2
+          yq -i --indent 4 'del(.paths."/health")' query_services.openapi.yaml
+          yq -i --indent 4 '(.tags[] | select(.name == "ArchiveQueryService")).x-scalar-ignore = true' query_services.openapi.yaml
+          yq -i --indent 4 '(.paths[][].tags) -= ["ArchiveQueryService"]' query_services.openapi.yaml
+
+      - name: Encode spec
+        id: encode
+        run: |
+          CONTENT=$(base64 -w 0 v2/api/archive-query-service/v2/query_services.openapi.yaml)
+          echo "spec_base64=$CONTENT" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch to qubic/integration
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/integration
-          event-type: api-docs-update
+          event-type: query-api-update
+          client-payload: '{"openapi_spec_base64": "${{ steps.encode.outputs.spec_base64 }}"}'
 
       - name: Dispatch to qubic/docs
         uses: peter-evans/repository-dispatch@v3
@@ -25,3 +59,4 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/docs
           event-type: query-api-update
+          client-payload: '{"openapi_spec_base64": "${{ steps.encode.outputs.spec_base64 }}"}'

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -36,11 +36,6 @@ openapi-v3-gen:
 	cd "$(PROTO_DIR)" && \
 	protoc --openapi_out=output_mode=source_relative,default_response=false:. $(OPT_ARGS) -I "$(PROTO_DIR)" \
 		query_services.proto
-	@echo "Cleaning up OpenAPI spec..."
-	cd "$(PROTO_DIR)" && \
-	yq -iy 'del(.paths."/health")' query_services.openapi.yaml && \
-	yq -iy '(.tags[] | select(.name == "ArchiveQueryService"))."x-scalar-ignore" = true' query_services.openapi.yaml && \
-	yq -iy '(.paths[][].tags) -= ["ArchiveQueryService"]' query_services.openapi.yaml
 
 test-cover:
 	@echo "Performing Go cover test..."


### PR DESCRIPTION
Move yq adjustments from Makefile to CI. The workflow now generates the spec from proto files, applies adjustments, and dispatches it.