### PR TITLE
Fix duplicate OpenAPI tag for Events endpoint

### DIFF
--- a/v2/api/archive-query-service/v2/query_services.proto
+++ b/v2/api/archive-query-service/v2/query_services.proto
@@ -352,7 +352,7 @@ service ArchiveQueryService {
   // | size   | uint32 | optional  | Defaults to 10. Maximum size is 1000. Zero value is ignored (uses default). |
   rpc GetEventLogs(GetEventLogsRequest) returns (GetEventLogsResponse) {
     option (openapi.v3.operation) = {
-      tags: ["Event (Beta)"]
+      tags: ["Events (Beta)"]
       summary: "Get Event Logs"
     };
 


### PR DESCRIPTION
## Summary
- The `getEventLogs` endpoint used tag `Event (Beta)` while the tag definition was `Events (Beta)`, causing a duplicate tag in the generated OpenAPI spec.
- Updated to `Events (Beta)` to match the tag definition.