### PR TITLE
Bugfix/middleware error codes

### DIFF
--- a/v2/grpc/middleware.go
+++ b/v2/grpc/middleware.go
@@ -81,12 +81,14 @@ func (i *IdentitiesValidatorInterceptor) checkFormat(idStr string, isLowercase b
 func (twb *TickWithinBoundsInterceptor) checkTickWithinArchiverIntervals(ctx context.Context, tickNumber uint32) error {
 	cachedStatus, err := twb.statusService.GetStatus(ctx)
 	if err != nil {
-		return status.Errorf(codes.Internal, "failed to get status from cache: %v", err)
+		log.Printf("[ERROR] (middleware) getting status from cache: %v", err)
+		return status.Error(codes.Internal, "failed to get status from cache")
 	}
 
 	tickIntervals, err := twb.statusService.GetProcessedTickIntervals(ctx)
 	if err != nil {
-		return status.Errorf(codes.Internal, "failed to get tick intervals from cache: %v", err)
+		log.Printf("[ERROR] (middleware) getting tick intervals from cache: %v", err)
+		return status.Error(codes.Internal, "failed to get tick intervals from cache")
 	}
 
 	lastProcessedTick := cachedStatus.LastProcessedTick
@@ -95,6 +97,7 @@ func (twb *TickWithinBoundsInterceptor) checkTickWithinArchiverIntervals(ctx con
 		st := status.Newf(codes.OutOfRange, "requested tick number %d is greater than last processed tick %d", tickNumber, lastProcessedTick)
 		st, err = st.WithDetails(&api.LastProcessedTick{TickNumber: lastProcessedTick})
 		if err != nil {
+			log.Printf("[ERROR] (middleware) creating out of range grpc error details: %v", err)
 			return status.Errorf(codes.Internal, "creating custom status")
 		}
 		return st.Err()
@@ -106,6 +109,7 @@ func (twb *TickWithinBoundsInterceptor) checkTickWithinArchiverIntervals(ctx con
 		st := status.Newf(codes.FailedPrecondition, "provided tick number %d was skipped by the system, next available tick is %d", tickNumber, nextAvailableTick)
 		st, err = st.WithDetails(&api.NextAvailableTick{NextTickNumber: nextAvailableTick})
 		if err != nil {
+			log.Printf("[ERROR] (middleware) creating failed precondition error details: %v", err)
 			return status.Errorf(codes.Internal, "creating custom status")
 		}
 		return st.Err()

--- a/v2/grpc/middleware.go
+++ b/v2/grpc/middleware.go
@@ -45,6 +45,7 @@ func (twb *TickWithinBoundsInterceptor) GetInterceptor(ctx context.Context, req 
 		break
 	}
 
+	// TODO doesn't this override the more accurate status code from above?
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Errorf("invalid tick number: %w", err).Error())
 	}

--- a/v2/grpc/middleware.go
+++ b/v2/grpc/middleware.go
@@ -95,7 +95,7 @@ func (twb *TickWithinBoundsInterceptor) checkTickWithinArchiverIntervals(ctx con
 	lastProcessedTick := cachedStatus.LastProcessedTick
 
 	if tickNumber > lastProcessedTick {
-		st := status.Newf(codes.FailedPrecondition, "requested tick number %d is greater than last processed tick %d", tickNumber, lastProcessedTick)
+		st := status.Newf(codes.OutOfRange, "requested tick number %d is greater than last processed tick %d", tickNumber, lastProcessedTick)
 		st, err = st.WithDetails(&api.LastProcessedTick{TickNumber: lastProcessedTick})
 		if err != nil {
 			return status.Errorf(codes.Internal, "creating custom status")
@@ -106,7 +106,7 @@ func (twb *TickWithinBoundsInterceptor) checkTickWithinArchiverIntervals(ctx con
 	processedTickIntervalsPerEpoch := tickIntervals
 	wasSkipped, nextAvailableTick := WasSkippedByArchive(tickNumber, processedTickIntervalsPerEpoch)
 	if wasSkipped {
-		st := status.Newf(codes.OutOfRange, "provided tick number %d was skipped by the system, next available tick is %d", tickNumber, nextAvailableTick)
+		st := status.Newf(codes.FailedPrecondition, "provided tick number %d was skipped by the system, next available tick is %d", tickNumber, nextAvailableTick)
 		st, err = st.WithDetails(&api.NextAvailableTick{NextTickNumber: nextAvailableTick})
 		if err != nil {
 			return status.Errorf(codes.Internal, "creating custom status")

--- a/v2/grpc/middleware.go
+++ b/v2/grpc/middleware.go
@@ -35,24 +35,20 @@ func (twb *TickWithinBoundsInterceptor) GetInterceptor(ctx context.Context, req 
 	var err error
 
 	switch request := req.(type) {
-
+	// errors returned here should be errors with grpc status codes (status.Errorf(...))
 	case *api.GetTickDataRequest:
 		err = twb.checkTickWithinArchiverIntervals(ctx, request.TickNumber)
 	case *api.GetTransactionsForTickRequest:
 		err = twb.checkTickWithinArchiverIntervals(ctx, request.TickNumber)
-
 	default:
 		break
 	}
 
-	// TODO doesn't this override the more accurate status code from above?
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Errorf("invalid tick number: %w", err).Error())
+		return nil, err
 	}
 
-	h, err := handler(ctx, req)
-
-	return h, err
+	return handler(ctx, req)
 }
 
 type IdentitiesValidatorInterceptor struct{}
@@ -164,7 +160,12 @@ func CreateTTLMapFromJSONFile(jsonFilePath string) (map[string]time.Duration, er
 	if err != nil {
 		return nil, fmt.Errorf("opening json file: %w", err)
 	}
-	defer file.Close()
+	defer func(file *os.File) {
+		e := file.Close()
+		if e != nil {
+			log.Printf("[ERROR] Failed to close file: %v", e)
+		}
+	}(file)
 
 	var rawMap map[string]string
 	if err := json.NewDecoder(file).Decode(&rawMap); err != nil {


### PR DESCRIPTION
* Do not wrap errors in an additional status object because it overwrites the original error code.
* Switch out of range and failed precondition errors:
   * If we have a tick in the future it's out of range because it will be fixed.
   * If we query a tick that was skipped it's failed precondition because this tick will never be available.

From the docs:

```
	// FailedPrecondition indicates operation was rejected because the
	// system is not in a state required for the operation's execution.
	// For example, directory to be deleted may be non-empty, an rmdir
	// operation is applied to a non-directory, etc.
```

```
	// OutOfRange means operation was attempted past the valid range.
	// E.g., seeking or reading past end of file.
	//
	// Unlike InvalidArgument, this error indicates a problem that may
	// be fixed if the system state changes. 

```