### PR TITLE
fix: Dispatch commit SHA instead of inlined OpenAPI spec

### DIFF
--- a/.github/workflows/api-docs-update-v2.yaml
+++ b/.github/workflows/api-docs-update-v2.yaml
@@ -12,46 +12,13 @@ jobs:
   api-docs-update-trigger:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.26.x
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
-
-      - name: Install protoc-gen-openapi
-        run: go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
-
-      - name: Generate OpenAPI spec
-        working-directory: v2
-        run: |
-          export PATH="$(go env GOPATH)/bin:$PATH"
-          make openapi-v3-gen
-
-      - name: Apply OpenAPI adjustments
-        run: |
-          cd v2/api/archive-query-service/v2
-          yq -i --indent 4 'del(.paths."/health")' query_services.openapi.yaml
-          yq -i --indent 4 '(.tags[] | select(.name == "ArchiveQueryService")).x-scalar-ignore = true' query_services.openapi.yaml
-          yq -i --indent 4 '(.paths[][].tags) -= ["ArchiveQueryService"]' query_services.openapi.yaml
-
-      - name: Encode spec
-        id: encode
-        run: |
-          CONTENT=$(base64 -w 0 v2/api/archive-query-service/v2/query_services.openapi.yaml)
-          echo "spec_base64=$CONTENT" >> "$GITHUB_OUTPUT"
-
       - name: Dispatch to qubic/integration
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/integration
           event-type: query-api-update
-          client-payload: '{"openapi_spec_base64": "${{ steps.encode.outputs.spec_base64 }}"}'
+          client-payload: '{"ref": "${{ github.sha }}"}'
 
       - name: Dispatch to qubic/docs
         uses: peter-evans/repository-dispatch@v3
@@ -59,4 +26,4 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/docs
           event-type: query-api-update
-          client-payload: '{"openapi_spec_base64": "${{ steps.encode.outputs.spec_base64 }}"}'
+          client-payload: '{"ref": "${{ github.sha }}"}'


### PR DESCRIPTION
The base64-encoded OpenAPI spec exceeds GitHub's 65535-character client_payload limit (https://github.com/qubic/archive-query-service/actions/runs/24986366554/job/73160555226). Send the commit SHA instead so receiving repositories can check out this repo and generate the spec themselves.