### PR TITLE
Add validation that log id range is only used together with tick number

### DIFF
--- a/v2/grpc/filters/validate.go
+++ b/v2/grpc/filters/validate.go
@@ -75,6 +75,11 @@ func VerifyNoConflictingFilters(queryFilters entities.Filters) error {
 		return err
 	}
 
+	err = validateRangeDependencies(queryFilters.Ranges, queryFilters.Include)
+	if err != nil {
+		return err
+	}
+
 	// we do not check the exclude filters against the should filters
 	// allow excluding values that are returned by applying the should filters
 	err = checkForConflictingKeys(keys, queryFilters.Exclude, false) // do not modify
@@ -91,6 +96,14 @@ func VerifyNoConflictingFilters(queryFilters entities.Filters) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateRangeDependencies(ranges map[string][]entities.Range, includes map[string][]string) error {
+	// we only accept log id ranges
+	if _, ok := ranges[EventFilterLogId]; ok && includes[EventFilterTickNumber] == nil {
+		return fmt.Errorf("log id range without tick number filter")
 	}
 	return nil
 }

--- a/v2/grpc/filters/validate_test.go
+++ b/v2/grpc/filters/validate_test.go
@@ -454,11 +454,79 @@ func TestVerifyNoConflictingFilters(t *testing.T) {
 			wantErr:    true,
 			errMessage: "duplicate [field1] filter",
 		},
+		{
+			name: "no error - logId range with tick number filter",
+			filters: entities.Filters{
+				Include: map[string][]string{
+					EventFilterTickNumber: {"1234"},
+				},
+				Exclude: map[string][]string{},
+				Ranges: map[string][]entities.Range{
+					EventFilterLogId: {{Operation: "gte", Value: "0"}},
+				},
+				Should: []entities.ShouldFilter{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error - logId range without tick number filter",
+			filters: entities.Filters{
+				Include: map[string][]string{},
+				Exclude: map[string][]string{},
+				Ranges: map[string][]entities.Range{
+					EventFilterLogId: {{Operation: "gte", Value: "0"}},
+				},
+				Should: []entities.ShouldFilter{},
+			},
+			wantErr:    true,
+			errMessage: "log id range without tick number filter",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := VerifyNoConflictingFilters(tt.filters)
+			if tt.wantErr {
+				require.ErrorContains(t, err, tt.errMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateRangeDependencies(t *testing.T) {
+	tests := []struct {
+		name       string
+		ranges     map[string][]entities.Range
+		includes   map[string][]string
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name: "logId range with tick number filter - no error",
+			ranges: map[string][]entities.Range{
+				EventFilterLogId: {{Operation: "gte", Value: "0"}},
+			},
+			includes: map[string][]string{
+				EventFilterTickNumber: {"1234"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "logId range without tick number filter - error",
+			ranges: map[string][]entities.Range{
+				EventFilterLogId: {{Operation: "gte", Value: "0"}},
+			},
+			includes:   map[string][]string{},
+			wantErr:    true,
+			errMessage: "log id range without tick number filter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRangeDependencies(tt.ranges, tt.includes)
 			if tt.wantErr {
 				require.ErrorContains(t, err, tt.errMessage)
 			} else {


### PR DESCRIPTION
* We would like to avoid 'full table scans' as we do not have index sorting on log id alone.
* Log id might be unique per epoch but there is no guarantee for that and we might change the log id handling in the ingestion pipeline and use our own ids.