### PR TITLE
Update max response size to 20 MB for upcoming tx payload increase

### DIFF
--- a/legacy/app/archive-query-service/main.go
+++ b/legacy/app/archive-query-service/main.go
@@ -45,7 +45,7 @@ func run() error {
 			EmptyTicksTtl            time.Duration `conf:"default:24h"` // nolint:revive
 			EmptyTicksUpdateInterval time.Duration `conf:"default:5s"`
 			MaxRecvSizeInMb          int           `conf:"default:1"`
-			MaxSendSizeInMb          int           `conf:"default:10"`
+			MaxSendSizeInMb          int           `conf:"default:20"`
 		}
 		ElasticSearch struct {
 			Address                   []string      `conf:"default:https://localhost:9200"`

--- a/v2/cmd/archive-query-service/main.go
+++ b/v2/cmd/archive-query-service/main.go
@@ -48,7 +48,7 @@ func run() error {
 			CacheEnabled          bool          `conf:"default:false"`
 			CacheTTLFile          string        `conf:"default:cache_ttl.json"`
 			MaxRecvSizeInMb       int           `conf:"default:1"`
-			MaxSendSizeInMb       int           `conf:"default:10"`
+			MaxSendSizeInMb       int           `conf:"default:20"`
 		}
 		Pagination struct {
 			MaxPageSize     uint32 `conf:"default:1000"`


### PR DESCRIPTION
* Payload can easily exceed 10 MB. One serialized tx data can have 4400+ bytes (proto) or 4500+ bytes (json).